### PR TITLE
add option to disable smart agent bundle use

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ git push heroku main
 Use the following environment variables to configure this buildpack
 
 | Environment Variable      | Required | Default                                             | Description                                                                                                                |
-| ----------------------    | -------- | -------                                             | -------------------------------------------------------------------------                                                  |
+|---------------------------|----------|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `SFX_AGENT_DISABLED`      | No       | `false`                                             | Whether to disable installing the smart agent as part of the buildpack.                                                    |
 | `SPLUNK_ACCESS_TOKEN`     | Yes      |                                                     | [Splunk access token](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html#admin-org-tokens). |
 | `SPLUNK_REALM`            | Yes      |                                                     | [Splunk realm](https://dev.splunk.com/observability/docs/realms_in_endpoints/).                                            |
 | `SPLUNK_API_URL`          | No       | `https://api.SPLUNK_REALM.signalfx.com`             | The Splunk API base URL.                                                                                                   |

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,12 @@ if [ -f "$ENV_DIR/SFX_AGENT_VERSION" ]; then
 fi
 signalfx_agent_tar="signalfx-agent-$SFX_AGENT_VERSION.tar.gz"
 
+# Check if the SignalFx Agent download is explicitly disabled
+SFX_AGENT_DISABLED=false
+if [ -f "$ENV_DIR/SFX_AGENT_DISABLED" ]; then
+  SFX_AGENT_DISABLED=$(cat "$ENV_DIR/SFX_AGENT_DISABLED")
+fi
+
 SPLUNK_CONFIG_DIR="$BUILD_DIR/.splunk"
 cp "$BUILDPACK_DIR/setup/config.yaml" "$SPLUNK_CONFIG_DIR"
 
@@ -52,19 +58,24 @@ if [ $? -ne 0 ]; then
     exit 1;
 fi
 
-echo "-----> Downloading SignalFx Agent Bundle $SFX_AGENT_VERSION ($signalfx_agent_tar)"
-wget -P "$SPLUNK_CONFIG_DIR/" "https://github.com/signalfx/signalfx-agent/releases/download/v$SFX_AGENT_VERSION/$signalfx_agent_tar" -o $signalfx_agent_tar > /dev/null 2>&1
-#curl -L "https://github.com/signalfx/signalfx-agent/releases/download/v$SFX_AGENT_VERSION/$signalfx_agent_tar" -o $SPLUNK_CONFIG_DIR/$signalfx_agent_tar > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    echo "Downloading agent tarball failed" | indent
-    echo "$SFX_AGENT_VERSION may not be a valid version of the SignalFx Agent." | indent
-    echo "Find valid versions here: https://github.com/signalfx/signalfx-agent/tags" | indent
-    exit 1;
+if [ "${SFX_AGENT_DISABLED}" = "true" ]; then
+    echo "-----> Skipping installing the SignalFx Agent Bundle"
+else
+    echo "-----> Downloading SignalFx Agent Bundle $SFX_AGENT_VERSION ($signalfx_agent_tar)"
+    wget -P "$SPLUNK_CONFIG_DIR/" "https://github.com/signalfx/signalfx-agent/releases/download/v$SFX_AGENT_VERSION/$signalfx_agent_tar" -o $signalfx_agent_tar > /dev/null 2>&1
+    #curl -L "https://github.com/signalfx/signalfx-agent/releases/download/v$SFX_AGENT_VERSION/$signalfx_agent_tar" -o $SPLUNK_CONFIG_DIR/$signalfx_agent_tar > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Downloading agent tarball failed" | indent
+        echo "$SFX_AGENT_VERSION may not be a valid version of the SignalFx Agent." | indent
+        echo "Find valid versions here: https://github.com/signalfx/signalfx-agent/tags" | indent
+        exit 1;
+    fi
+
+    echo "-----> Extracting SignalFx Agent Bundle"
+    tar -xf "$SPLUNK_CONFIG_DIR/$signalfx_agent_tar" -C "$SPLUNK_CONFIG_DIR"
+    rm -f "$SPLUNK_CONFIG_DIR/$signalfx_agent_tar"
 fi
 
-echo "-----> Extracting SignalFx Agent Bundle"
-tar -xf "$SPLUNK_CONFIG_DIR/$signalfx_agent_tar" -C "$SPLUNK_CONFIG_DIR"
-rm -f "$SPLUNK_CONFIG_DIR/$signalfx_agent_tar"
 
 mkdir -p "$BUILD_DIR/.profile.d"
 cp "$BUILDPACK_DIR/setup/agent.sh" "$BUILD_DIR/.profile.d/"

--- a/setup/config_without_sa.yaml
+++ b/setup/config_without_sa.yaml
@@ -1,0 +1,141 @@
+config_sources:
+  env:
+    defaults:
+      HEROKU_DYNO_ID: "unset"
+      HEROKU_APP_ID: "unset"
+      HEROKU_APP_NAME: "unset"
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+  http_forwarder:
+    ingress:
+      endpoint: 0.0.0.0:6060
+    egress:
+      endpoint: "${SPLUNK_API_URL}"
+      # Use instead when sending to gateway
+      #endpoint: "${SPLUNK_GATEWAY_URL}"
+  zpages:
+    #endpoint: 0.0.0.0:55679
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:14250
+      thrift_binary:
+        endpoint: 0.0.0.0:6832
+      thrift_compact:
+        endpoint: 0.0.0.0:6831
+      thrift_http:
+        endpoint: 0.0.0.0:14268
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  # This section is used to collect the OpenTelemetry Collector metrics
+  # Even if just a Splunk APM customer, these metrics are included
+  prometheus/internal:
+    config:
+      scrape_configs:
+      - job_name: 'otel-collector'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: '.*grpc_io.*'
+            action: drop
+  signalfx:
+    endpoint: 0.0.0.0:9943
+  zipkin:
+    endpoint: 0.0.0.0:9411
+
+processors:
+  batch:
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # In general, the ballast should be set to 1/3 of the collector's memory, the limit
+  # should be 90% of the collector's memory up to 2GB. The simplest way to specify the
+  # ballast size is set the value of SPLUNK_BALLAST_SIZE_MIB env variable. Alternatively, the
+  # --mem-ballast-size-mib command line flag can be passed and take priority.
+  # For more information about memory limiter, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
+  memory_limiter:
+    ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    check_interval: 2s
+    limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  attributes/heroku:
+    actions:
+    - action: insert
+      key: dyno_id
+      value: ${env:HEROKU_DYNO_ID}
+    - action: insert
+      key: app_id
+      value: ${env:HEROKU_APP_ID}
+    - action: insert
+      key: app_name
+      value: ${env:HEROKU_APP_NAME}
+  metricstransform/heroku:
+    transforms:
+    - include: .*
+      match_type: regexp
+      action: update
+      operations:
+        - action: add_label
+          new_label: dyno_id
+          new_value: ${env:HEROKU_DYNO_ID}
+        - action: add_label
+          new_label: app_id
+          new_value: ${env:HEROKU_APP_ID}
+        - action: add_label
+          new_label: app_name
+          new_value: ${env:HEROKU_APP_NAME}
+  # Optional: The following processor can be used to add a default "deployment.environment" attribute to the logs and 
+  # traces when it's not populated by instrumentation libraries.
+  # If enabled, make sure to enable this processor in the pipeline below.
+  #resource/add_environment:
+    #attributes:
+      #- action: insert
+        #key: deployment.environment
+        #value: staging/production/...
+
+exporters:
+  # Traces
+  sapm:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    endpoint: "${SPLUNK_TRACE_URL}"
+  # Metrics + Events
+  signalfx:
+    access_token: "${SPLUNK_ACCESS_TOKEN}"
+    api_url: "${SPLUNK_API_URL}"
+    ingest_url: "${SPLUNK_INGEST_URL}"
+  # Send to gateway
+  #otlp:
+  # endpoint: "${SPLUNK_GATEWAY_URL}:4317"
+  # insecure: true
+  # Debug
+  logging:
+    loglevel: debug
+
+service:
+  extensions: [health_check, http_forwarder, zpages]
+  pipelines:
+    traces:
+      receivers: [jaeger, otlp, zipkin]
+      processors:
+      - memory_limiter
+      - batch
+      - attributes/heroku
+      #- resource/add_environment
+      exporters: [sapm, signalfx]
+    metrics:
+      receivers: [otlp, signalfx]
+      processors: [memory_limiter, batch, metricstransform/heroku]
+      exporters: [signalfx]
+    metrics/internal:
+      receivers: [prometheus/internal]
+      processors: [memory_limiter, batch, metricstransform/heroku]
+      exporters: [signalfx]


### PR DESCRIPTION
Fixes #4

This pull request allows a user to explicitly disable the Smart agent bundle download, to save on disk space.

1. Remove the existing buildpack if you have installed it in the past:
`heroku buildpacks:remove https://github.com/signalfx/splunk-otel-collector-heroku.git\#v0.0.1`
2. Add a new configuration entry to explicitly disable the smart agent download:
`heroku config:set SFX_AGENT_DISABLED=true`
3. Add the new buildpack:
`heroku buildpacks:add https://github.com/atoulme/splunk-otel-collector-heroku.git\#disable_sfx_agent`
4. Push a release like usual. Check the output of the push, looking for this line:
`remote: -----> Skipping installing the SignalFx Agent Bundle`

That's it! You should be set.
Note disabling the smart agent has side effects. We will no longer collect heroku metadata about your application. I have opened https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16833 to create a native receiver to replace this monitor going forward.
