### PR TITLE
Removed memory_ballast

### DIFF
--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -21,8 +21,6 @@ extensions:
       configDir: "${SPLUNK_COLLECTD_DIR}"
   zpages:
     #endpoint: 0.0.0.0:55679
-  memory_ballast:
-    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
 receivers:
   jaeger:
@@ -128,7 +126,7 @@ exporters:
     loglevel: debug
 
 service:
-  extensions: [health_check, http_forwarder, zpages, memory_ballast]
+  extensions: [health_check, http_forwarder, zpages]
   pipelines:
     traces:
       receivers: [jaeger, otlp, smartagent/signalfx-forwarder, zipkin]

--- a/setup/config_without_sa.yaml
+++ b/setup/config_without_sa.yaml
@@ -17,8 +17,6 @@ extensions:
       #endpoint: "${SPLUNK_GATEWAY_URL}"
   zpages:
     #endpoint: 0.0.0.0:55679
-  memory_ballast:
-    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
 receivers:
   jaeger:

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -17,8 +17,6 @@ extensions:
       #endpoint: "${SPLUNK_GATEWAY_URL}"
   zpages:
     #endpoint: 0.0.0.0:55679
-  memory_ballast:
-    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
 receivers:
   jaeger:
@@ -117,7 +115,7 @@ exporters:
     loglevel: debug
 
 service:
-  extensions: [health_check, http_forwarder, zpages, memory_ballast]
+  extensions: [health_check, http_forwarder, zpages]
   pipelines:
     traces:
       receivers: [jaeger, otlp, zipkin]


### PR DESCRIPTION
As of Splunk Otel Collector 0.97.0 we are no longer using `memory_ballast`, instead using `GOMEMLIMIT` env var ( if set) or setting a soft limit via API call. 